### PR TITLE
Make the builds work correctly on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ script: "script/cibuild"
 matrix:
   include:
     - rvm: 2.5
+      env: SKIP_RUBOCOP=""
     - rvm: 2.1
+      env: SKIP_RUBOCOP="true"
     - rvm: 2.0
+      env: SKIP_RUBOCOP="true"
     - rvm: 1.9
+      env: SKIP_RUBOCOP="true"

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ gemspec
 
 group :development, :test do
   gem "rspec", "~> 3.7.0", ">= 3.7.0"
+end
+
+group :rubocop do
   gem "rubocop", "= 0.49.1"
   gem "rubocop-github", "~> 0.5.0", ">= 0.5.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    simplecov-erb (0.1)
+    simplecov-erb (0.1.1)
       simplecov
 
 GEM

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -8,7 +8,12 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 cd "$DIR"
 rm -rf "${DIR}/.bundle"
 bundle config --local path "vendor/bundle"
-bundle install --without="" --no-prune --path "vendor/bundle" --binstubs --local
+if [ "$SKIP_RUBOCOP" ]; then
+  without="rubocop"
+else
+  without=""
+fi
+bundle install --without="$without" --no-prune --path "vendor/bundle" --binstubs --local
 
 echo "Completed script/bootstrap successfully"
 exit 0

--- a/script/cibuild
+++ b/script/cibuild
@@ -10,7 +10,11 @@ cd "$DIR"
 "$DIR/script/bootstrap"
 
 # -- Rubocop the code we care about (skip the fixture)
-bundle exec rubocop lib/ spec/ views/
+if [ -z "$SKIP_RUBOCOP" ]; then
+  bundle exec rubocop lib/ spec/ views/
+else
+  echo "** Skipped rubocop tests, since \$SKIP_RUBOCOP is set."
+fi
 
 # -- rspec tests
 bundle exec rspec spec/

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ RSpec.configure do |config|
   config.add_setting :tempdir
 
   config.before(:suite) do
-    config.tempdir = Dir.mktmpdir("simplecov-erb-")
+    config.tempdir = Dir.mktmpdir
     ENV["SIMPLECOV_ERB_TEMPDIR"] = config.tempdir
 
     basedir = File.expand_path("..", File.dirname(__FILE__))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,10 +2,11 @@
 require "rubygems"
 require "bundler/setup"
 require "open3"
+require "rspec"
+require "tmpdir"
+
 require "simplecov"
 require "simplecov-erb"
-
-require "rspec"
 
 RSpec.configure do |config|
   config.add_setting :tempdir


### PR DESCRIPTION
- Fix call to mktmpdir
- Update Gemfile.lock with the current version number
- Require tmpdir -- seems not to be needed on my machine, but is needed here
- Skip rubocop on old versions of ruby